### PR TITLE
fix: Handle both Date and Timestamp types in AddToGoogleCalendar

### DIFF
--- a/app/components/AddToGoogleCalendar.tsx
+++ b/app/components/AddToGoogleCalendar.tsx
@@ -12,7 +12,7 @@ export interface AddToGoogleCalendarProps {
 export default function AddToGoogleCalendar({ booking, className }: AddToGoogleCalendarProps) {
   const createGoogleCalendarUrl = () => {
     const [hours, minutes] = booking.time.split(':');
-    const startDate = new Date(booking.date);
+    const startDate = new Date(booking.date instanceof Date ? booking.date : booking.date.toDate());
     startDate.setHours(parseInt(hours), parseInt(minutes), 0);
     
     const endDate = new Date(startDate);


### PR DESCRIPTION
- Add type checking to handle both JavaScript Date and Firebase Timestamp objects
- Ensure proper date conversion for Google Calendar URL